### PR TITLE
Configurable custom data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,14 @@ Add Structlog log level to your nameko config file:
    STRUCTLOG:
       DEVELOPMENT_MODE: ${DEV:false}
       WORKER_NAME: ${WORKER_NAME:false}
-
+      CUSTOM_DATA:
+         message: event
+         type: msg_type
+         service_name: logger
    ...
+
+CUSTOM_DATA: can contain any key that you want to use in log.
+
 
 
 Include the ``StructlogDependency`` dependency in your service class:
@@ -47,13 +53,13 @@ Include the ``StructlogDependency`` dependency in your service class:
    from nameko_structlog import StructlogDependency
 
    class MyService(object):
-      name = 'demo'
+      name = "demo"
 
       log = StructlogDependency()
 
       @rpc 
       def my_method(self, name):
-         self.log.info('Your name is '.format(name))
+         self.log.info("Your name is {}".format(name), msg_type="greeting")
 
 
 Run your service, providing the config file:
@@ -61,6 +67,10 @@ Run your service, providing the config file:
 .. code-block:: shell
 
    $ nameko run service --config config.yaml
+
+   $ nameko shell --config config.yaml
+   >>> n.rpc.demo.my_method("Alice")
+   {"level": "info", "log_transaction_id": "0eb52621-f570-4e5a-a0e6-b4e55e6e9df4", "message": "Your name is Alice ", "service_name": "demo", "timestamp": "2020-09-10T22:09:16.191540Z", "type": "greeting"}
 
 
 Credits

--- a/nameko_structlog/nameko_structlog.py
+++ b/nameko_structlog/nameko_structlog.py
@@ -29,10 +29,10 @@ class StructlogDependency(DependencyProvider):
             return {**custom_data, **event_dict}
 
     def setup(self):
-        structlog_config = self.container.config.get('STRUCTLOG', {})
-        self.development_mode = structlog_config.get('DEVELOPMENT_MODE', False)
-        self.include_worker_name = structlog_config.get('WORKER_NAME', False)
-        self.unittesting = structlog_config.get('FOR_TESTING', False)
+        structlog_config = self.container.config.get("STRUCTLOG", {})
+        self.development_mode = structlog_config.get("DEVELOPMENT_MODE", False)
+        self.include_worker_name = structlog_config.get("WORKER_NAME", False)
+        self.unittesting = structlog_config.get("FOR_TESTING", False)
         self.custom_data = structlog_config.get("CUSTOM_DATA", {})
         self.logger_by_service_name = dict()
 
@@ -45,9 +45,7 @@ class StructlogDependency(DependencyProvider):
 
             if self.unittesting:
                 log_factory = structlog.ReturnLoggerFactory
-                chain = [
-                    structlog.dev.ConsoleRenderer(colors=False)
-                ]
+                chain = [structlog.dev.ConsoleRenderer(colors=False)]
             else:
                 log_factory = structlog.stdlib.LoggerFactory
 
@@ -56,15 +54,13 @@ class StructlogDependency(DependencyProvider):
                     structlog.stdlib.add_logger_name,
                     structlog.stdlib.add_log_level,
                     structlog.stdlib.PositionalArgumentsFormatter(),
-                    structlog.processors.TimeStamper(fmt='iso'),
+                    structlog.processors.TimeStamper(fmt="iso"),
                     structlog.processors.StackInfoRenderer(),
                     structlog.processors.format_exc_info,
                     structlog.processors.UnicodeDecoder(),
                 ]
                 if self.development_mode:
-                    chain.append(
-                        structlog.dev.ConsoleRenderer(colors=use_colors)
-                    )
+                    chain.append(structlog.dev.ConsoleRenderer(colors=use_colors))
                 else:
                     chain.extend(
                         [

--- a/nameko_structlog/nameko_structlog.py
+++ b/nameko_structlog/nameko_structlog.py
@@ -1,6 +1,8 @@
 """
 Nameko Structlog Dependency Provider.
 """
+import uuid
+
 from nameko.extensions import DependencyProvider
 
 import structlog
@@ -16,12 +18,26 @@ else:
 class StructlogDependency(DependencyProvider):
     """Dependency Provider of Structlog."""
 
+    class CustomDataProcessor(object):
+        def __init__(self, custom_data):
+            self.custom_data = custom_data
+
+        def __call__(self, wrapped_logger, method_name, event_dict):
+            custom_data = {
+                key: event_dict.pop(value, None) for key, value in self.custom_data.items()
+            }
+            return {**custom_data, **event_dict}
+
     def setup(self):
         structlog_config = self.container.config.get('STRUCTLOG', {})
         self.development_mode = structlog_config.get('DEVELOPMENT_MODE', False)
         self.include_worker_name = structlog_config.get('WORKER_NAME', False)
         self.unittesting = structlog_config.get('FOR_TESTING', False)
+        self.custom_data = structlog_config.get("CUSTOM_DATA", {})
         self.logger_by_service_name = dict()
+
+    def generate_uuid(self):
+        return str(uuid.uuid4())
 
     def get_dependency(self, worker_ctx):
         service_name = worker_ctx.service_name
@@ -44,15 +60,14 @@ class StructlogDependency(DependencyProvider):
                     structlog.processors.StackInfoRenderer(),
                     structlog.processors.format_exc_info,
                     structlog.processors.UnicodeDecoder(),
+                    self.CustomDataProcessor(self.custom_data),
                 ]
                 if self.development_mode:
                     chain.append(
                         structlog.dev.ConsoleRenderer(colors=use_colors)
                     )
                 else:
-                    chain.append(
-                        structlog.processors.JSONRenderer(indent=2, sort_keys=True)
-                    )
+                    chain.append(structlog.processors.JSONRenderer(sort_keys=True))
 
             structlog.configure(
                 processors=chain,
@@ -63,8 +78,12 @@ class StructlogDependency(DependencyProvider):
             )
 
             if self.include_worker_name:
-                self.logger_by_service_name[service_name] = structlog.get_logger(service_name).new(entrypoint=worker_ctx.call_id)  # noqa pylint: disable=line-too-long
+                self.logger_by_service_name[service_name] = structlog.get_logger(service_name).new(
+                    entrypoint=worker_ctx.call_id, log_transaction_id=self.generate_uuid()
+                )  # noqa pylint: disable=line-too-long
             else:
-                self.logger_by_service_name[service_name] = structlog.get_logger(service_name).new()  # noqa pylint: disable=line-too-long
+                self.logger_by_service_name[service_name] = structlog.get_logger(service_name).new(
+                    log_transaction_id=self.generate_uuid()
+                )  # noqa pylint: disable=line-too-long
 
         return self.logger_by_service_name[service_name]

--- a/tests/test_nameko_structlog.py
+++ b/tests/test_nameko_structlog.py
@@ -8,7 +8,9 @@ import pytest
 
 from nameko.rpc import rpc
 from nameko.testing.services import (
-    entrypoint_hook, entrypoint_waiter, get_extension,
+    entrypoint_hook,
+    entrypoint_waiter,
+    get_extension,
 )
 
 from nameko_structlog import StructlogDependency
@@ -17,25 +19,20 @@ from nameko_structlog import StructlogDependency
 @pytest.fixture
 def config():
 
-    return {
-        'STRUCTLOG': {
-            'FOR_TESTING': True
-        }
-    }
+    return {"STRUCTLOG": {"FOR_TESTING": True}}
 
 
 @pytest.fixture
 def service_cls():
-
     class Service(object):
-        name = 'demo'
+        name = "demo"
 
         log = StructlogDependency()
 
         @rpc
         def foo(self):
-            self.log.info('bar')  # pylint: disable=no-member
-            return 'OK'
+            self.log.info("bar")  # pylint: disable=no-member
+            return "OK"
 
     return Service
 
@@ -46,9 +43,9 @@ def test_structlog_setup(container_factory, service_cls, config):
 
     struct_log = get_extension(container, StructlogDependency)
 
-    with entrypoint_hook(container, 'foo') as foo:
-        with entrypoint_waiter(container, 'foo'):
-            assert foo() == 'OK'
+    with entrypoint_hook(container, "foo") as foo:
+        with entrypoint_waiter(container, "foo"):
+            assert foo() == "OK"
             # StructlogDependency returns a structlog logger per service name
-            service_logger = struct_log.logger_by_service_name['demo']
-            assert 'bar' == service_logger.info('bar')
+            service_logger = struct_log.logger_by_service_name["demo"]
+            assert "bar" == service_logger.info("bar")

--- a/tests/test_nameko_structlog.py
+++ b/tests/test_nameko_structlog.py
@@ -15,14 +15,13 @@ from nameko_structlog import StructlogDependency
 
 
 @pytest.fixture
-def config(rabbit_config):
-    config = rabbit_config.copy()
-    config.update({
+def config():
+
+    return {
         'STRUCTLOG': {
             'FOR_TESTING': True
         }
-    })
-    return config
+    }
 
 
 @pytest.fixture


### PR DESCRIPTION
### Custom data
Add custom data on log message using the `CustomDataProcessor`
User can declare the custom data mapping at his `config.yaml` file
ex: 
```yaml
 STRUCTLOG:
      DEVELOPMENT_MODE: ${DEV:false}
      WORKER_NAME: ${WORKER_NAME:false}
      CUSTOM_DATA:
         message: event
         type: msg_type
         service_name: logger
```

### Log indent
Remove indent at json log (resolves https://github.com/tyler46/nameko-structlog/issues/3)

### log_transaction_id
Added `log_transaction_id` key with value `uuid` for every group of logs for better investigation

### Bind `initial_values`
I noticed when the service is executed more than once the `initial_values` (in this case the `entrypoint` value when `WORKER_NAME=True` ) are not being used from structlog

The solution was to bind it at the return of every call 