### PR TITLE
Configurable log keys

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,13 @@ Add Structlog log level to your nameko config file:
    STRUCTLOG:
       DEVELOPMENT_MODE: ${DEV:false}
       WORKER_NAME: ${WORKER_NAME:false}
-
+      SORT_KEYS: ${SORT_KEYS:true}
+      CUSTOM_KEYS:
+         service_name: logger
    ...
+
+CUSTOM_DATA: can contain any key that you want to use in log.
+
 
 
 Include the ``StructlogDependency`` dependency in your service class:
@@ -47,13 +52,13 @@ Include the ``StructlogDependency`` dependency in your service class:
    from nameko_structlog import StructlogDependency
 
    class MyService(object):
-      name = 'demo'
+      name = "demo"
 
       log = StructlogDependency()
 
       @rpc 
       def my_method(self, name):
-         self.log.info('Your name is '.format(name))
+         self.log.info(message="Your name is {}".format(name), type="greeting")
 
 
 Run your service, providing the config file:
@@ -61,6 +66,10 @@ Run your service, providing the config file:
 .. code-block:: shell
 
    $ nameko run service --config config.yaml
+
+   $ nameko shell --config config.yaml
+   >>> n.rpc.demo.my_method("Alice")
+   {"level": "info", "log_transaction_id": "b2cd5506-339e-4e59-9a14-a3cd7548bfe5", "logger": "demo", "message": "Your name is Alice", "service_name": "logger", "timestamp": "2020-09-27T11:24:30.379918Z", "type": "greeting"}
 
 
 Credits

--- a/nameko_structlog/nameko_structlog.py
+++ b/nameko_structlog/nameko_structlog.py
@@ -53,7 +53,7 @@ class StructlogDependency(DependencyProvider):
                 if self.development_mode:
                     chain.append(structlog.dev.ConsoleRenderer(colors=use_colors))
                 else:
-                    chain.extend([structlog.processors.JSONRenderer(sort_keys=self.sort_keys)])
+                    chain.append(structlog.processors.JSONRenderer(sort_keys=self.sort_keys))
 
             structlog.configure(
                 processors=chain,

--- a/nameko_structlog/nameko_structlog.py
+++ b/nameko_structlog/nameko_structlog.py
@@ -1,6 +1,8 @@
 """
 Nameko Structlog Dependency Provider.
 """
+import uuid
+
 from nameko.extensions import DependencyProvider
 
 import structlog
@@ -17,11 +19,16 @@ class StructlogDependency(DependencyProvider):
     """Dependency Provider of Structlog."""
 
     def setup(self):
-        structlog_config = self.container.config.get('STRUCTLOG', {})
-        self.development_mode = structlog_config.get('DEVELOPMENT_MODE', False)
-        self.include_worker_name = structlog_config.get('WORKER_NAME', False)
-        self.unittesting = structlog_config.get('FOR_TESTING', False)
+        structlog_config = self.container.config.get("STRUCTLOG", {})
+        self.development_mode = structlog_config.get("DEVELOPMENT_MODE", False)
+        self.include_worker_name = structlog_config.get("WORKER_NAME", False)
+        self.unittesting = structlog_config.get("FOR_TESTING", False)
+        self.custom_keys = structlog_config.get("CUSTOM_KEYS", {})
+        self.sort_keys = structlog_config.get("SORT_KEYS", True)
         self.logger_by_service_name = dict()
+
+    def generate_uuid(self):
+        return str(uuid.uuid4())
 
     def get_dependency(self, worker_ctx):
         service_name = worker_ctx.service_name
@@ -29,9 +36,7 @@ class StructlogDependency(DependencyProvider):
 
             if self.unittesting:
                 log_factory = structlog.ReturnLoggerFactory
-                chain = [
-                    structlog.dev.ConsoleRenderer(colors=False)
-                ]
+                chain = [structlog.dev.ConsoleRenderer(colors=False)]
             else:
                 log_factory = structlog.stdlib.LoggerFactory
 
@@ -40,19 +45,15 @@ class StructlogDependency(DependencyProvider):
                     structlog.stdlib.add_logger_name,
                     structlog.stdlib.add_log_level,
                     structlog.stdlib.PositionalArgumentsFormatter(),
-                    structlog.processors.TimeStamper(fmt='iso'),
+                    structlog.processors.TimeStamper(fmt="iso"),
                     structlog.processors.StackInfoRenderer(),
                     structlog.processors.format_exc_info,
                     structlog.processors.UnicodeDecoder(),
                 ]
                 if self.development_mode:
-                    chain.append(
-                        structlog.dev.ConsoleRenderer(colors=use_colors)
-                    )
+                    chain.append(structlog.dev.ConsoleRenderer(colors=use_colors))
                 else:
-                    chain.append(
-                        structlog.processors.JSONRenderer(indent=2, sort_keys=True)
-                    )
+                    chain.extend([structlog.processors.JSONRenderer(sort_keys=self.sort_keys)])
 
             structlog.configure(
                 processors=chain,
@@ -62,9 +63,11 @@ class StructlogDependency(DependencyProvider):
                 cache_logger_on_first_use=True,
             )
 
-            if self.include_worker_name:
-                self.logger_by_service_name[service_name] = structlog.get_logger(service_name).new(entrypoint=worker_ctx.call_id)  # noqa pylint: disable=line-too-long
-            else:
-                self.logger_by_service_name[service_name] = structlog.get_logger(service_name).new()  # noqa pylint: disable=line-too-long
+            self.logger_by_service_name[service_name] = structlog.get_logger(service_name).new()
 
-        return self.logger_by_service_name[service_name]
+        initial_values = {"log_transaction_id": self.generate_uuid(), **self.custom_keys}
+
+        if self.include_worker_name:
+            initial_values.update({"entrypoint": worker_ctx.call_id})
+
+        return self.logger_by_service_name[service_name].bind(**initial_values)

--- a/tests/test_nameko_structlog.py
+++ b/tests/test_nameko_structlog.py
@@ -8,35 +8,31 @@ import pytest
 
 from nameko.rpc import rpc
 from nameko.testing.services import (
-    entrypoint_hook, entrypoint_waiter, get_extension,
+    entrypoint_hook,
+    entrypoint_waiter,
+    get_extension,
 )
 
 from nameko_structlog import StructlogDependency
 
 
 @pytest.fixture
-def config(rabbit_config):
-    config = rabbit_config.copy()
-    config.update({
-        'STRUCTLOG': {
-            'FOR_TESTING': True
-        }
-    })
-    return config
+def config():
+
+    return {"STRUCTLOG": {"FOR_TESTING": True}}
 
 
 @pytest.fixture
 def service_cls():
-
     class Service(object):
-        name = 'demo'
+        name = "demo"
 
         log = StructlogDependency()
 
         @rpc
         def foo(self):
-            self.log.info('bar')  # pylint: disable=no-member
-            return 'OK'
+            self.log.info("bar")  # pylint: disable=no-member
+            return "OK"
 
     return Service
 
@@ -47,9 +43,9 @@ def test_structlog_setup(container_factory, service_cls, config):
 
     struct_log = get_extension(container, StructlogDependency)
 
-    with entrypoint_hook(container, 'foo') as foo:
-        with entrypoint_waiter(container, 'foo'):
-            assert foo() == 'OK'
+    with entrypoint_hook(container, "foo") as foo:
+        with entrypoint_waiter(container, "foo"):
+            assert foo() == "OK"
             # StructlogDependency returns a structlog logger per service name
-            service_logger = struct_log.logger_by_service_name['demo']
-            assert 'bar' == service_logger.info('bar')
+            service_logger = struct_log.logger_by_service_name["demo"]
+            assert "bar" == service_logger.info("bar")


### PR DESCRIPTION
## Configurable log keys
Configure global keys at every log message using the `CUSTOM_KEY` option at `config.yaml` of nameko service.
ex: 
```yaml
STRUCTLOG:
  CUSTOM_KEYS:
    service_name: logger
``` 
### Configurable sort keys
Add the option for user to decide if the log keys should be sorted or not.
As default value is `True`.
```yaml
STRUCTLOG:
    SORT_KEYS: {true|false}
``` 

## Log indent
Remove indent at json log (resolves #3)

log_transaction_id
Added log_transaction_id key with value uuid for every group of logs for better investigation

## Bind initial_values
I noticed when the service is executed more than once the initial_values (in this case the entrypoint value when WORKER_NAME=True ) are not being used from structlog

The solution was to bind it at the return of every call