### PR TITLE
Add structlog.is_configured check before configuring structlog

### DIFF
--- a/nameko_structlog/nameko_structlog.py
+++ b/nameko_structlog/nameko_structlog.py
@@ -57,13 +57,14 @@ class StructlogLogger:
         return str(uuid.uuid4())
 
     def get_logger(self):
-        structlog.configure(
-            processors=self.chain,
-            context_class=structlog.threadlocal.wrap_dict(dict),
-            logger_factory=structlog.stdlib.LoggerFactory(),
-            wrapper_class=structlog.stdlib.BoundLogger,
-            cache_logger_on_first_use=True,
-        )
+        if not structlog.is_configured():
+            structlog.configure(
+                processors=self.chain,
+                context_class=structlog.threadlocal.wrap_dict(dict),
+                logger_factory=structlog.stdlib.LoggerFactory(),
+                wrapper_class=structlog.stdlib.BoundLogger,
+                cache_logger_on_first_use=True,
+            )
 
         logger = structlog.get_logger(self.service_name).new()
         return logger.bind(**self.initial_values)


### PR DESCRIPTION
Checks if `structlog` is already configured, if not then `nameko_structlog` default configuration is set, otherwise configuration is skipped.
- It creates a possibility to configure `structlog` with custom values for the whole project that uses nameko-structlog.
- Such functionality can be especially useful in projects that initialize loggers with both `StructlogDependency` and `structlog.getLogger()`.
- Additionally because of the fact that `configure` would be called only once it slightly improves performance of nameko-structlog. 